### PR TITLE
MCE-18519_reintroduce_go_mysql_error_handling error handling logic

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -98,6 +98,13 @@ func NewCanal(cfg *Config) (*Canal, error) {
 	c.delay = new(uint32)
 
 	var err error
+	if err = c.master.infoLoader.Load(c.master.Setter); err != nil {
+		return nil, errors.Trace(err)
+	} else if len(c.master.Addr) != 0 && c.master.Addr != c.cfg.Addr {
+		c.cfg.Logger.Infof("MySQL addr %s in old master.info, but new %s, reset", c.master.Addr, c.cfg.Addr)
+		// may use another MySQL, reset
+		c.master = &masterInfo{infoLoader: c.master.infoLoader} // keep the configured info loader
+	}
 
 	if err = c.prepareDumper(); err != nil {
 		return nil, errors.Trace(err)

--- a/canal/canal.go
+++ b/canal/canal.go
@@ -63,8 +63,8 @@ var UnknownTableRetryPeriod = time.Second * time.Duration(10)
 var ErrExcludedTable = errors.New("excluded table meta")
 
 // 5 loops stand for 10 minutes, after which it will give up and throw an alert
-const maxAttempts int = 5
-const waitForRetrySeconds time.Duration = time.Duration(20 * time.Second)
+const maxAttempts = 5
+const waitForRetrySeconds = 20 * time.Second
 
 func NewCanal(cfg *Config) (*Canal, error) {
 	c := new(Canal)

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -82,7 +82,8 @@ func (s *canalTestSuite) SetUpSuite(c *C) {
 	s.c.SetEventHandler(&testEventHandler{c: c})
 	go func() {
 		set, _ := mysql.ParseGTIDSet("mysql", "")
-		err = s.c.StartFromGTID(set)
+		syncErrorCh := make(chan error, 1)
+		err = s.c.StartFromGTID(set, syncErrorCh)
 		c.Assert(err, IsNil)
 	}()
 }

--- a/canal/sync.go
+++ b/canal/sync.go
@@ -171,6 +171,8 @@ func (c *Canal) runSyncBinlog() error {
 			c.master.Update(pos)
 			c.master.UpdateTimestamp(ev.Header.Timestamp)
 
+			c.proofOfSuccess = true
+
 			if err := c.eventHandler.OnPosSynced(ev.Header, pos, c.master.GTIDSet(), force); err != nil {
 				return errors.Trace(err)
 			}

--- a/cmd/go-canal/main.go
+++ b/cmd/go-canal/main.go
@@ -83,7 +83,8 @@ func main() {
 	}
 
 	go func() {
-		err = c.RunFrom(startPos)
+		syncErrorCh := make(chan error, 1)
+		err = c.RunFrom(startPos, syncErrorCh)
 		if err != nil {
 			fmt.Printf("start canal err %v", err)
 		}


### PR DESCRIPTION
replaying MCE-17245 that was left pending when upgrading with upstream